### PR TITLE
FEATURE: Allow to prepend elements

### DIFF
--- a/Classes/Middleware/SlipstreamMiddleware.php
+++ b/Classes/Middleware/SlipstreamMiddleware.php
@@ -15,13 +15,13 @@ class SlipstreamMiddleware implements MiddlewareInterface
      * @var SlipStreamService
      * @Flow\Inject
      */
-    protected $slipStramService;
+    protected $slipStreamService;
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $next): ResponseInterface
     {
         $response = $next->handle($request);
         if ($response->getHeaderLine('X-Slipstream') == 'enabled') {
-            return $this->slipStramService->processResponse($response);
+            return $this->slipStreamService->processResponse($response);
         } else {
             return $response;
         }

--- a/Classes/Service/SlipStreamService.php
+++ b/Classes/Service/SlipStreamService.php
@@ -82,23 +82,26 @@ class SlipStreamService
         }
 
         foreach ($nodesByTargetAndContentHash as $targetPath => $configurations) {
-            $prepend = [];
-            $append = [];
-            foreach ($configurations as $config) {
-                if ($config['prepend']) {
-                    $prepend[] = $config['node'];
-                } else {
-                    $append[] = $config['node'];
-                }
-            }
             $query = $xPath->query($targetPath);
             if ($query && $query->count()) {
+                $targetNode = $query->item(0);
+
+                $prepend = [];
+                $append = [];
+                foreach ($configurations as $config) {
+                    if ($config['prepend']) {
+                        $prepend[] = $config['node'];
+                    } else {
+                        $append[] = $config['node'];
+                    }
+                }
                 $hasPrepend = count($prepend);
                 $hasAppend = count($append);
-                $targetNode = $query->item(0);
+
                 if ($hasPrepend) {
                     $firstChildNode = $targetNode->firstChild;
                 }
+
                 if ($this->debugMode) {
                     $comment = 'slipstream-for: ' . $targetPath . ' ';
                     if ($hasPrepend) {
@@ -108,6 +111,7 @@ class SlipStreamService
                         $targetNode->appendChild($domDocument->createComment($comment . 'begin'));
                     }
                 }
+
                 foreach ($prepend as $node) {
                     $targetNode->insertBefore($node, $firstChildNode);
                 }

--- a/Classes/Service/SlipStreamService.php
+++ b/Classes/Service/SlipStreamService.php
@@ -93,16 +93,18 @@ class SlipStreamService
             }
             $query = $xPath->query($targetPath);
             if ($query && $query->count()) {
+                $hasPrepend = count($prepend);
+                $hasAppend = count($append);
                 $targetNode = $query->item(0);
-                if (count($prepend)) {
+                if ($hasPrepend) {
                     $firstChildNode = $targetNode->firstChild;
                 }
                 if ($this->debugMode) {
                     $comment = 'slipstream-for: ' . $targetPath . ' ';
-                    if (count($prepend)) {
+                    if ($hasPrepend) {
                         $targetNode->insertBefore($domDocument->createComment($comment . 'prepend begin'), $firstChildNode);
                     }
-                    if (count($append)) {
+                    if ($hasAppend) {
                         $targetNode->appendChild($domDocument->createComment($comment . 'begin'));
                     }
                 }
@@ -114,10 +116,10 @@ class SlipStreamService
                 }
 
                 if ($this->debugMode) {
-                    if (count($prepend)) {
+                    if ($hasPrepend) {
                         $targetNode->insertBefore($domDocument->createComment($comment . 'prepend end'), $firstChildNode);
                     }
-                    if (count($append)) {
+                    if ($hasAppend) {
                         $targetNode->appendChild($domDocument->createComment($comment . 'end'));
                     }
                 }

--- a/Configuration/Development/Settings.yaml
+++ b/Configuration/Development/Settings.yaml
@@ -1,3 +1,4 @@
 Sitegeist:
   Slipstream:
     debugMode: true
+    removeSlipstreamAttributes: false

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -14,4 +14,4 @@ Neos:
 Sitegeist:
   Slipstream:
     debugMode: false
-
+    removeSlipstreamAttributes: true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can mark any html fragment to be moved to the head of the document by
 adding a `data-slipstream` attribute.
 
 ```html
-    <script data-slipstream src="yourCustomSCript.js" />
+    <script data-slipstream src="yourCustomScript.js"></script>
     <div>your component</div>
 ```
 
@@ -29,12 +29,21 @@ is added to the header.
 By defining the `data-slipstream` attribute with an xpath the target can be altered. 
 
 ```html
-    <script data-slipstream="//body" src="yourCustomSCript.js" />
+    <script data-slipstream="//body" src="yourCustomScript.js"></script>
     <div>your component</div>
 ```
 
-When the setting `Sitegeist.Slipstream.debugMode` is enabled html comments are rendered to mark where tags were removed
-and inserted. This is enabled in Development Context by default.
+To prepend the tag to the given target, you can add the `data-slipstream-prepend` attribute:
+
+```html
+    <script data-slipstream="//body" data-slipstream-prepend src="yourCustomScriptAfterOpenendBody.js"></script>
+    <script data-slipstream data-slipstream-prepend src="yourCustomScriptAfterOpenendHead.js"></script>
+```
+
+When the setting `Sitegeist.Slipstream.debugMode` is enabled, html comments are rendered to mark where tags were removed
+and inserted. This is enabled in Development Context by default.  
+If the setting `Sitegeist.Slipstream.removeSlipstreamAttributes` is enabled, the attributes from slipstream gets removed. 
+This is disabled in Development Context by default.
 
 ## Inner working and performance
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can mark any html fragment to be moved to the head of the document by
 adding a `data-slipstream` attribute.
 
 ```html
-    <script data-slipstream href="yourCustomSCript.js" />
+    <script data-slipstream src="yourCustomSCript.js" />
     <div>your component</div>
 ```
 
@@ -29,7 +29,7 @@ is added to the header.
 By defining the `data-slipstream` attribute with an xpath the target can be altered. 
 
 ```html
-    <script data-slipstream="//body" href="yourCustomSCript.js" />
+    <script data-slipstream="//body" src="yourCustomSCript.js" />
     <div>your component</div>
 ```
 


### PR DESCRIPTION
- Allow to prepend elements to the given target. This is done with the new attribute `data-slipstream-prepend`
- Also added a setting to remove the slipstream attributes (Enabled in Production Context)
- Fix also some typos in the Readme
- Fix typo in `SlipstreamMiddleware.php`