### PR TITLE
FEATURE: Allow to prepend elements

### DIFF
--- a/Classes/Http/SlipStreamComponent.php
+++ b/Classes/Http/SlipStreamComponent.php
@@ -19,7 +19,7 @@ class SlipStreamComponent implements ComponentInterface
      * @var SlipStreamService
      * @Flow\Inject
      */
-    protected $slipStramService;
+    protected $slipStreamService;
 
     /**
      * Just call makeStandardsCompliant on the Response for now
@@ -31,7 +31,7 @@ class SlipStreamComponent implements ComponentInterface
     {
         $response = $componentContext->getHttpResponse();
         if ($response->getHeaderLine('X-Slipstream') == 'enabled') {
-            $response = $this->slipStramService->processResponse($response);
+            $response = $this->slipStreamService->processResponse($response);
             $componentContext->replaceHttpResponse($response);
         }
     }

--- a/Classes/Service/SlipStreamService.php
+++ b/Classes/Service/SlipStreamService.php
@@ -15,6 +15,12 @@ class SlipStreamService
     protected $debugMode;
 
     /**
+     * @var bool
+     * @Flow\InjectConfiguration(path="removeSlipstreamAttributes")
+     */
+    protected $removeAttributes;
+
+    /**
      * Modify the given response and return a new one with the data-slipstream elements moved to
      * the target location
      *
@@ -53,30 +59,73 @@ class SlipStreamService
             if (empty($target)) {
                 $target = '//head';
             }
+
+            $prepend = $node->hasAttribute('data-slipstream-prepend');
             $contentHash = md5($content);
-            $nodesByTargetAndContentHash[$target][$contentHash] = $node->cloneNode(true);
+            $clone = $node->cloneNode(true);
+            if ($this->removeAttributes) {
+                $clone->removeAttribute('data-slipstream');
+                $clone->removeAttribute('data-slipstream-prepend');
+            }
+            $nodesByTargetAndContentHash[$target][$contentHash] = [
+                'prepend' => $prepend,
+                'node' => $clone
+            ];
 
             // in debug mode leave a comment behind
             if ($this->debugMode) {
-                $comment = $domDocument->createComment(' ' . $content . ' ') ;
+                $comment = $domDocument->createComment(' ' . $content . ' ');
                 $node->parentNode->insertBefore($comment, $node);
             }
 
             $node->parentNode->removeChild($node);
         }
 
-        foreach ($nodesByTargetAndContentHash as $targetPath => $nodes){
+        foreach ($nodesByTargetAndContentHash as $targetPath => $configurations) {
             $query = $xPath->query($targetPath);
             if ($query && $query->count()) {
                 $targetNode = $query->item(0);
-                if ($this->debugMode) {
-                    $targetNode->appendChild($domDocument->createComment(' slipstream-for: ' . $targetPath . ' begin '));
+
+                $prepend = [];
+                $append = [];
+                foreach ($configurations as $config) {
+                    if ($config['prepend']) {
+                        $prepend[] = $config['node'];
+                    } else {
+                        $append[] = $config['node'];
+                    }
                 }
-                foreach ($nodes as $anchorNode) {
-                    $targetNode->appendChild($anchorNode);
+                $hasPrepend = count($prepend);
+                $hasAppend = count($append);
+
+                if ($hasPrepend) {
+                    $firstChildNode = $targetNode->firstChild;
                 }
+
                 if ($this->debugMode) {
-                    $targetNode->appendChild($domDocument->createComment(' slipstream-for: ' . $targetPath . ' end '));
+                    $comment = 'slipstream-for: ' . $targetPath . ' ';
+                    if ($hasPrepend) {
+                        $targetNode->insertBefore($domDocument->createComment($comment . 'prepend begin'), $firstChildNode);
+                    }
+                    if ($hasAppend) {
+                        $targetNode->appendChild($domDocument->createComment($comment . 'begin'));
+                    }
+                }
+
+                foreach ($prepend as $node) {
+                    $targetNode->insertBefore($node, $firstChildNode);
+                }
+                foreach ($append as $node) {
+                    $targetNode->appendChild($node);
+                }
+
+                if ($this->debugMode) {
+                    if ($hasPrepend) {
+                        $targetNode->insertBefore($domDocument->createComment($comment . 'prepend end'), $firstChildNode);
+                    }
+                    if ($hasAppend) {
+                        $targetNode->appendChild($domDocument->createComment($comment . 'end'));
+                    }
                 }
             }
         }

--- a/Configuration/Development/Settings.yaml
+++ b/Configuration/Development/Settings.yaml
@@ -1,3 +1,4 @@
 Sitegeist:
   Slipstream:
     debugMode: true
+    removeSlipstreamAttributes: false

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -16,3 +16,4 @@ Neos:
 Sitegeist:
   Slipstream:
     debugMode: false
+    removeSlipstreamAttributes: true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can mark any html fragment to be moved to the head of the document by
 adding a `data-slipstream` attribute.
 
 ```html
-    <script data-slipstream href="yourCustomSCript.js" />
+    <script data-slipstream src="yourCustomScript.js"></script>
     <div>your component</div>
 ```
 
@@ -29,12 +29,21 @@ is added to the header.
 By defining the `data-slipstream` attribute with an xpath the target can be altered. 
 
 ```html
-    <script data-slipstream="//body" href="yourCustomSCript.js" />
+    <script data-slipstream="//body" src="yourCustomScript.js"></script>
     <div>your component</div>
 ```
 
-When the setting `Sitegeist.Slipstream.debugMode` is enabled html comments are rendered to mark where tags were removed
-and inserted. This is enabled in Development Context by default.
+To prepend the tag to the given target, you can add the `data-slipstream-prepend` attribute:
+
+```html
+    <script data-slipstream="//body" data-slipstream-prepend src="yourCustomScriptAfterOpenendBody.js"></script>
+    <script data-slipstream data-slipstream-prepend src="yourCustomScriptAfterOpenendHead.js"></script>
+```
+
+When the setting `Sitegeist.Slipstream.debugMode` is enabled, html comments are rendered to mark where tags were removed
+and inserted. This is enabled in Development Context by default.  
+If the setting `Sitegeist.Slipstream.removeSlipstreamAttributes` is enabled, the attributes from slipstream gets removed. 
+This is disabled in Development Context by default.
 
 ## Inner working and performance
 
@@ -43,12 +52,12 @@ This header is added to Neos.Neos:Page and Sitegeist.Monocle:Preview.Page alread
 neos and monocle right away. For other controllers you will have to add the `X-Slipstream: Enabled` manually.
 
 Since the response body is parsed and modified this adds a small performance penalty to every reqest. However
-the package is designed to work together with Flowpack.FullpaheCache which will im turn cache the whole result 
+the package is designed to work together with Flowpack.FullpageCache which will im turn cache the whole result 
 and mitigate the small performance drawback. 
 
 ## Installation
 
-Sitegeist.Slipstream is available via packagist run `composer require sitegeist/slipstream`.
+Sitegeist.Slipstream is available via packagist run `composer require "sitegeist/slipstream:^1.0"`.
 
 We use semantic-versioning so every breaking change will increase the major-version number.
 


### PR DESCRIPTION
This is basically the same as PR #1, just for the old version 

- Allow to prepend elements to the given target. This is done with the new attribute `data-slipstream-prepend`
- Also added a setting to remove the slipstream attributes (Enabled in Production Context)
- Fix also some typos in the Readme
- Fix typo in `SlipStreamComponent.php`