### PR TITLE
Task: Add explicit neos dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "name": "sitegeist/slipstream",
     "license": "GPL-3.0-or-later",
     "require": {
-        "neos/flow": "^7.0 || dev-master"
+        "neos/flow": "^7.0 || dev-master",
+        "neos/neos": "^7.0 || dev-master"
     },
     "suggest": {
         "sitegeist/monocle": "*",


### PR DESCRIPTION
Without this slipstream could end up beeing loaded before neos which effectively disabled the additional headers sent with neos pages.