### PR TITLE
Fix: Remove Header if not in debug mode

### DIFF
--- a/Classes/Service/SlipStreamService.php
+++ b/Classes/Service/SlipStreamService.php
@@ -148,7 +148,7 @@ class SlipStreamService
 
         $response = $response->withBody(stream_for($alteredBody));
         if (!$this->debugMode) {
-            $response = $response->withoutHeader('X-Slipstream-Enabled');
+            $response = $response->withoutHeader('X-Slipstream');
         }
 
         // restore previous parsing behavior


### PR DESCRIPTION
Currently, the header gets not removed, even when the debug mode is set to `false`