### PR TITLE
Fix: Remove Header if not in debug mode (v1)

### DIFF
--- a/Classes/Service/SlipStreamService.php
+++ b/Classes/Service/SlipStreamService.php
@@ -138,7 +138,7 @@ class SlipStreamService
 
         $response = $response->withBody(stream_for($alteredBody));
         if (!$this->debugMode) {
-            $response = $response->withoutHeader('X-Slipstream-Enabled');
+            $response = $response->withoutHeader('X-Slipstream');
         }
 
         // restore previous parsing behavior


### PR DESCRIPTION
Currently, the header gets not removed, even when the debug mode is set to `false`

> This is the same as PR #10, just for the v1 branch