### PR TITLE
Update: Remove hard dependency to neos/neos (v1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "license": "GPL-3.0-or-later",
     "require": {
         "php": "^7.2",
-        "neos/flow": "^6.0 || dev-master",
-        "neos/neos": "*"
+        "neos/flow": "^6.0 || dev-master"
     },
     "suggest": {
         "sitegeist/monocle": "*",
@@ -19,7 +18,12 @@
     },
     "extra": {
         "neos": {
-            "package-key": "Sitegeist.Slipstream"
+            "package-key": "Sitegeist.Slipstream",
+             "loading-order": {
+                 "after": [
+                     "neos/neos"
+                 ]
+             }
         }
     }
 }


### PR DESCRIPTION
The loading order is preserved with the loading-order setting in the extra field.
With this change, we could even change the license to MIT

> This is the same as PR #9, just for the v1 branch