### PR TITLE
TASK: Add tests and basic ci qs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: build
+
+on:
+  push:
+      branches:
+        - 'main'
+  pull_request: ~
+
+jobs:
+    test:
+        name: "Test (PHP ${{ matrix.php-versions }}, Flow ${{ matrix.flow-versions }})"
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php-versions: ['8.0', '8.1']
+                flow-versions: ['8.3']
+                include:
+                  - php-versions: '8.0'
+                    flow-versions: '8.0'
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  path: ${{ env.FLOW_FOLDER }}
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php-versions }}
+                  extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite
+                  ini-values: date.timezone="Africa/Tunis", opcache.fast_shutdown=0, apc.enable_cli=on
+
+            - name: Set Flow Version
+              run: composer require neos/flow ^${{ matrix.flow-versions }} --no-progress --no-interaction
+
+            - name: Run Tests
+              run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+Packages
+vendor

--- a/Classes/Service/SlipStreamService.php
+++ b/Classes/Service/SlipStreamService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Sitegeist\Slipstream\Service;
 
 use Neos\Flow\Annotations as Flow;
@@ -7,7 +8,6 @@ use GuzzleHttp\Psr7\Utils;
 
 class SlipStreamService
 {
-
     /**
      * @var bool
      * @Flow\InjectConfiguration(path="debugMode")
@@ -36,6 +36,27 @@ class SlipStreamService
     {
         $html = $response->getBody()->getContents();
 
+        $alteredHtml = $this->processHtml($html);
+
+        if (is_null($alteredHtml)) {
+            $response->getBody()->rewind();
+            return $response;
+        }
+
+        $response = $response->withBody(Utils::streamFor($alteredHtml));
+        if (!$this->debugMode) {
+            $response = $response->withoutHeader('X-Slipstream');
+        }
+
+        return $response;
+    }
+
+    public function processHtml(string $html): ?string
+    {
+        if (!str_contains($html, 'data-slipstream')) {
+            return null;
+        }
+
         // Starting with Neos 7.3 it is possible to have attributes with @ (e.g. @click).
         // This replacement preserves attributes with @ character
         $html = str_replace(self::AT_CHARACTER_SEARCH, self::AT_CHARACTER_REPLACEMENT, $html);
@@ -51,113 +72,144 @@ class SlipStreamService
 
         // in case of parsing errors return original body
         if (!$success) {
-            $response->getBody()->rewind();
-            return $response;
+            if ($useInternalErrorsBackup !== true) {
+                libxml_use_internal_errors($useInternalErrorsBackup);
+            }
+            return null;
         }
 
         $xPath = new \DOMXPath($domDocument);
 
         $sourceNodes = $xPath->query("//*[@data-slipstream]");
-        $nodesByTargetAndContentHash = [];
-        foreach ($sourceNodes as $node) {
+        if ($sourceNodes instanceof \DOMNodeList) {
+            $nodesByTargetAndContentHash = [];
+
             /**
-             * @var \DOMNode $node
+             * @var \DOMElement $node
              */
-            $content = $domDocument->saveHTML($node);
-            $target = $node->getAttribute('data-slipstream');
-            if (empty($target)) {
-                $target = '//head';
+            foreach ($sourceNodes as $node) {
+                /**
+                 * @var string $content
+                 */
+                $content = $domDocument->saveHTML($node);
+                $target = $node->getAttribute('data-slipstream');
+                if (empty($target)) {
+                    $target = '//head';
+                }
+
+                $prepend = $node->hasAttribute('data-slipstream-prepend');
+                $contentHash = md5($content);
+
+                /**
+                 * @var \DOMElement $clone
+                 */
+                $clone = $node->cloneNode(true);
+                if ($this->removeAttributes) {
+                    $clone->removeAttribute('data-slipstream');
+                    $clone->removeAttribute('data-slipstream-prepend');
+                }
+                $nodesByTargetAndContentHash[$target][$contentHash] = [
+                    'prepend' => $prepend,
+                    'node' => $clone
+                ];
+
+                /**
+                 * @var \DOMElement $parentNode
+                 */
+                $parentNode =  $node->parentNode;
+                // in debug mode leave a comment behind
+                if ($this->debugMode) {
+                    $comment = $domDocument->createComment(' ' . $content . ' ');
+                    $parentNode->insertBefore($comment, $node);
+                }
+
+                $parentNode->removeChild($node);
             }
 
-            $prepend = $node->hasAttribute('data-slipstream-prepend');
-            $contentHash = md5($content);
-            $clone = $node->cloneNode(true);
-            if ($this->removeAttributes) {
-                $clone->removeAttribute('data-slipstream');
-                $clone->removeAttribute('data-slipstream-prepend');
-            }
-            $nodesByTargetAndContentHash[$target][$contentHash] = [
-                'prepend' => $prepend,
-                'node' => $clone
-            ];
 
-            // in debug mode leave a comment behind
-            if ($this->debugMode) {
-                $comment = $domDocument->createComment(' ' . $content . ' ');
-                $node->parentNode->insertBefore($comment, $node);
-            }
+            foreach ($nodesByTargetAndContentHash as $targetPath => $configurations) {
+                $query = $xPath->query($targetPath);
+                if ($query && $query->count()) {
+                    /**
+                     * @var \DOMElement $targetNode
+                     */
+                    $targetNode = $query->item(0);
 
-            $node->parentNode->removeChild($node);
-        }
+                    $prepend = [];
+                    $append = [];
+                    foreach ($configurations as $config) {
+                        if ($config['prepend']) {
+                            $prepend[] = $config['node'];
+                        } else {
+                            $append[] = $config['node'];
+                        }
+                    }
+                    $hasPrepend = count($prepend);
+                    $hasAppend = count($append);
 
-        foreach ($nodesByTargetAndContentHash as $targetPath => $configurations) {
-            $query = $xPath->query($targetPath);
-            if ($query && $query->count()) {
-                $targetNode = $query->item(0);
-
-                $prepend = [];
-                $append = [];
-                foreach ($configurations as $config) {
-                    if ($config['prepend']) {
-                        $prepend[] = $config['node'];
+                    if ($hasPrepend) {
+                        $nodeToInsertBefore = $targetNode->firstChild;
                     } else {
-                        $append[] = $config['node'];
+                        $nodeToInsertBefore = null;
                     }
-                }
-                $hasPrepend = count($prepend);
-                $hasAppend = count($append);
 
-                if ($hasPrepend) {
-                    $firstChildNode = $targetNode->firstChild;
-                }
-
-                if ($this->debugMode) {
-                    $comment = 'slipstream-for: ' . $targetPath . ' ';
-                    if ($hasPrepend) {
-                        $targetNode->insertBefore($domDocument->createComment($comment . 'prepend begin'), $firstChildNode);
+                    if ($this->debugMode) {
+                        if ($hasPrepend) {
+                            if ($nodeToInsertBefore) {
+                                $targetNode->insertBefore($domDocument->createComment('slipstream-for: ' . $targetPath . ' prepend begin'), $nodeToInsertBefore);
+                            } else {
+                                $targetNode->appendChild($domDocument->createComment('slipstream-for: ' . $targetPath . ' prepend begin'));
+                            }
+                        }
+                        if ($hasAppend) {
+                            $targetNode->appendChild($domDocument->createComment('slipstream-for: ' . $targetPath . ' begin'));
+                        }
                     }
-                    if ($hasAppend) {
-                        $targetNode->appendChild($domDocument->createComment($comment . 'begin'));
-                    }
-                }
 
-                foreach ($prepend as $node) {
-                    $targetNode->insertBefore($node, $firstChildNode);
-                }
-                foreach ($append as $node) {
-                    $targetNode->appendChild($node);
-                }
-
-                if ($this->debugMode) {
-                    if ($hasPrepend) {
-                        $targetNode->insertBefore($domDocument->createComment($comment . 'prepend end'), $firstChildNode);
+                    foreach ($prepend as $node) {
+                        if ($nodeToInsertBefore) {
+                            $targetNode->insertBefore($node, $nodeToInsertBefore);
+                        } else {
+                            $targetNode->appendChild($node);
+                        }
                     }
-                    if ($hasAppend) {
-                        $targetNode->appendChild($domDocument->createComment($comment . 'end'));
+                    foreach ($append as $node) {
+                        $targetNode->appendChild($node);
+                    }
+
+                    if ($this->debugMode) {
+                        if ($hasPrepend) {
+                            if ($nodeToInsertBefore) {
+                                $targetNode->insertBefore($domDocument->createComment('slipstream-for: ' . $targetPath . ' prepend end'), $nodeToInsertBefore);
+                            } else {
+                                $targetNode->appendChild($domDocument->createComment('slipstream-for: ' . $targetPath . ' prepend end'));
+                            }
+                        }
+                        if ($hasAppend) {
+                            $targetNode->appendChild($domDocument->createComment('slipstream-for: ' . $targetPath . ' end'));
+                        }
                     }
                 }
             }
         }
 
         if ($hasXmlDeclaration) {
-            $alteredBody = $domDocument->saveHTML();
+            $alteredHtml = $domDocument->saveHTML();
         } else {
-            $alteredBody = $domDocument->saveHTML($domDocument->documentElement);
+            $alteredHtml = $domDocument->saveHTML($domDocument->documentElement);
+        }
+
+        if ($alteredHtml === false) {
+            return null;
         }
 
         // Replace the interal @ character with the original one
-        $alteredBody = str_replace(self::AT_CHARACTER_REPLACEMENT, self::AT_CHARACTER_SEARCH, $alteredBody);
+        $alteredHtml = str_replace(self::AT_CHARACTER_REPLACEMENT, self::AT_CHARACTER_SEARCH, $alteredHtml);
 
-        $response = $response->withBody(Utils::streamFor($alteredBody));
-        if (!$this->debugMode) {
-            $response = $response->withoutHeader('X-Slipstream');
-        }
-
-        // restore previous parsing behavior
         if ($useInternalErrorsBackup !== true) {
             libxml_use_internal_errors($useInternalErrorsBackup);
         }
 
-        return $response;
+        return $alteredHtml;
     }
 }

--- a/Classes/Service/SlipStreamService.php
+++ b/Classes/Service/SlipStreamService.php
@@ -25,6 +25,8 @@ class SlipStreamService
 
     protected const AT_CHARACTER_SEARCH = ' @';
 
+    protected const HTML_DOCTYPE = '<!DOCTYPE html>';
+
     /**
      * Modify the given response and return a new one with the data-slipstream elements moved to
      * the target location
@@ -61,8 +63,11 @@ class SlipStreamService
         // This replacement preserves attributes with @ character
         $html = str_replace(self::AT_CHARACTER_SEARCH, self::AT_CHARACTER_REPLACEMENT, $html);
 
-        // detect xml or html declaration
-        $hasXmlDeclaration = (substr($html, 0, 5) === '<?xml') || (substr($html, 0, 15) === '<!DOCTYPE html>');
+        // detect html doctype
+        $hasHtmlDoctype = substr($html, 0, 15) === self::HTML_DOCTYPE;
+
+        // detect xml declaration
+        $hasXmlDeclaration = substr($html, 0, 5) === '<?xml';
 
         // ignore xml parsing errors
         $useInternalErrorsBackup = libxml_use_internal_errors(true);
@@ -153,6 +158,7 @@ class SlipStreamService
                         $nodeToInsertBefore = null;
                     }
 
+                    // start comment
                     if ($this->debugMode) {
                         if ($hasPrepend) {
                             if ($nodeToInsertBefore) {
@@ -177,6 +183,7 @@ class SlipStreamService
                         $targetNode->appendChild($node);
                     }
 
+                    // end comment
                     if ($this->debugMode) {
                         if ($hasPrepend) {
                             if ($nodeToInsertBefore) {
@@ -210,6 +217,6 @@ class SlipStreamService
             libxml_use_internal_errors($useInternalErrorsBackup);
         }
 
-        return $alteredHtml;
+        return $hasHtmlDoctype ? self::HTML_DOCTYPE . $alteredHtml : $alteredHtml ;
     }
 }

--- a/Tests/Unit/SlipstreamServiceTest.php
+++ b/Tests/Unit/SlipstreamServiceTest.php
@@ -207,6 +207,66 @@ class SlipstreamServiceTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function specialCharactersWorkInContentAndSlipstreamWithDoctype() {
+        $service = $this->createService();
+        $input = <<<EOF
+            <!DOCTYPE html>
+            <html>
+                <head></head>
+                <body>
+                    fooÄÖÜ<div data-slipstream>slipped content ÄÖÜ</div>barÄÖÜ
+                </body>
+            </html>
+            EOF;
+        $output = <<<EOF
+            <!DOCTYPE html><html>
+                <head><div data-slipstream>slipped content ÄÖÜ</div></head>
+                <body>
+                    fooÄÖÜbarÄÖÜ
+                </body>
+            </html>
+            EOF;
+
+        $result = $service->processHtml($input);
+        $this->assertSame(
+            $output,
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function specialCharactersWorkInContentAndSlipstreamWithoutDoctype() {
+        $service = $this->createService();
+        $input = <<<EOF
+            <html>
+                <head></head>
+                <body>
+                    fooÄÖÜ<div data-slipstream>slipped content ÄÖÜ</div>barÄÖÜ
+                </body>
+            </html>
+            EOF;
+        $output = <<<EOF
+            <html>
+                <head><div data-slipstream>slipped content ÄÖÜ</div></head>
+                <body>
+                    fooÄÖÜbarÄÖÜ
+                </body>
+            </html>
+            EOF;
+
+        $result = $service->processHtml($input);
+        $this->assertSame(
+            $output,
+            $result
+        );
+    }
+
+
     public function createService(bool $debugMode = false, bool $removeAttributes = false): SlipStreamService
     {
         $service = new SlipStreamService();

--- a/Tests/Unit/SlipstreamServiceTest.php
+++ b/Tests/Unit/SlipstreamServiceTest.php
@@ -1,0 +1,236 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\Slipstream\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use ReflectionProperty;
+use Sitegeist\Slipstream\Service\SlipStreamService;
+
+class SlipstreamServiceTest extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function nonHtmlContentIsRejected() {
+        $service = $this->createService();
+        $input = <<<EOF
+            {
+                "foo": {
+                    "bar" : "baz"
+                }
+            }
+            EOF;
+
+        $result = $service->processHtml($input);
+        $this->assertSame(
+            null,
+            $result
+        );
+    }
+
+
+    /**
+     * @test
+     */
+    public function moveToHeaderByDefaultWorks() {
+        $service = $this->createService();
+        $input = <<<EOF
+            <html>
+                <head></head>
+                <body>
+                    foo<div data-slipstream>slipped content</div>bar
+                </body>
+            </html>
+            EOF;
+        $output = <<<EOF
+            <html>
+                <head><div data-slipstream>slipped content</div></head>
+                <body>
+                    foobar
+                </body>
+            </html>
+            EOF;
+
+        $result = $service->processHtml($input);
+        $this->assertSame(
+            $output,
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function deduplicationWorks() {
+        $service = $this->createService();
+        $input = <<<EOF
+            <html>
+                <head></head>
+                <body>
+                    foo<div data-slipstream>slipped content</div>bar<div data-slipstream>slipped content</div>baz<div data-slipstream>other slipped content</div>bam
+                </body>
+            </html>
+            EOF;
+        $output = <<<EOF
+            <html>
+                <head><div data-slipstream>slipped content</div><div data-slipstream>other slipped content</div></head>
+                <body>
+                    foobarbazbam
+                </body>
+            </html>
+            EOF;
+
+        $result = $service->processHtml($input);
+        $this->assertSame(
+            $output,
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function debugInformationIsAdded() {
+        $service = $this->createService(true);
+        $input = <<<EOF
+            <html>
+                <head></head>
+                <body>
+                    foo<div data-slipstream>slipped content</div>bar
+                </body>
+            </html>
+            EOF;
+        $output = <<<EOF
+            <html>
+                <head><!--slipstream-for: //head begin--><div data-slipstream>slipped content</div><!--slipstream-for: //head end--></head>
+                <body>
+                    foo<!-- <div data-slipstream>slipped content</div> -->bar
+                </body>
+            </html>
+            EOF;
+
+        $result = $service->processHtml($input);
+        $this->assertSame(
+            $output,
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function attributesAreRemovedAdded() {
+        $service = $this->createService(false, true);
+        $input = <<<EOF
+            <html>
+                <head></head>
+                <body>
+                    foo<div data-slipstream>slipped content</div>bar
+                </body>
+            </html>
+            EOF;
+        $output = <<<EOF
+            <html>
+                <head><div>slipped content</div></head>
+                <body>
+                    foobar
+                </body>
+            </html>
+            EOF;
+
+        $result = $service->processHtml($input);
+        $this->assertSame(
+            $output,
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function targetSpecificationWorks() {
+        $service = $this->createService();
+        $input = <<<EOF
+            <html>
+                <head></head>
+                <body>
+                    foo<div data-slipstream="//body">slipped content</div>bar
+                </body>
+            </html>
+            EOF;
+        $output = <<<EOF
+            <html>
+                <head></head>
+                <body>
+                    foobar
+                <div data-slipstream="//body">slipped content</div></body>
+            </html>
+            EOF;
+
+        $result = $service->processHtml($input);
+        $this->assertSame(
+            $output,
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function targetSpecificationWorksWithPrepend() {
+        $service = $this->createService();
+        $input = <<<EOF
+            <html>
+                <head></head>
+                <body>
+                    foo<div data-slipstream="//body" data-slipstream-prepend>slipped content</div>bar
+                </body>
+            </html>
+            EOF;
+        $output = <<<EOF
+            <html>
+                <head></head>
+                <body><div data-slipstream="//body" data-slipstream-prepend>slipped content</div>
+                    foobar
+                </body>
+            </html>
+            EOF;
+
+        $result = $service->processHtml($input);
+        $this->assertSame(
+            $output,
+            $result
+        );
+    }
+
+    public function createService(bool $debugMode = false, bool $removeAttributes = false): SlipStreamService
+    {
+        $service = new SlipStreamService();
+
+        $debugModeProperty = new ReflectionProperty($service, "debugMode");
+        $debugModeProperty->setAccessible(true);
+        $debugModeProperty->setValue($service, $debugMode);
+
+        $removeAttributesProperty = new ReflectionProperty($service, "removeAttributes");
+        $removeAttributesProperty->setAccessible(true);
+        $removeAttributesProperty->setValue($service, $removeAttributes);
+
+        return $service;
+    }
+
+    protected function createResponse(string $content): ResponseInterface
+    {
+        $streamMock = $this->createMock(StreamInterface::class);
+        $streamMock->expects($this->any())->method('getContents')->willReturn($content);
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->expects($this->any())->method('getBody')->willReturn($streamMock);
+        return $responseMock;
+    }
+
+
+}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,12 @@
     "name": "sitegeist/slipstream",
     "license": "GPL-3.0-or-later",
     "require": {
-        "neos/flow": "^7.0 || ^8.0 || dev-master"
+        "neos/flow": "^8.0 || ^9.0 || dev-master"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5",
+        "phpstan/phpstan": "^1.8",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "suggest": {
         "sitegeist/monocle": "An living-styleguide for Neos that is based on the actual fusion-code",
@@ -23,6 +28,19 @@
                     "neos/neos"
                 ]
             }
+        }
+    },
+    "scripts": {
+        "fix:style": "phpcbf --colors --standard=PSR12 Classes",
+        "test:style": "phpcs --colors -n --standard=PSR12 Classes",
+        "test:stan": "phpstan analyse Classes",
+        "test:unit": "phpunit Tests/Unit",
+        "cc": "phpstan clear cache",
+        "test": ["composer install", "composer test:style" , "composer test:stan", "composer test:unit"]
+    },
+    "config": {
+        "allow-plugins": {
+            "neos/composer-plugin": true
         }
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+	level: 8
+	paths:
+		- Classes
+	reportUnmatchedIgnoredErrors: true


### PR DESCRIPTION
Add code linting, static analysis and basic tests

Also the following is fixed:
- Umlauts are no longer converted into html-entities when `<!DOCTYPE html>` was set 
   Resolves: #18
- The parsing of the document is omitted unlss `data-slipstream` is found in the body 
  Resolves: #8
